### PR TITLE
Set EXLA as the default backend

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,6 +63,8 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :nx, :default_backend, EXLA.Backend
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
By default the tensors use the pure-Elixir `Nx.BinaryBackend`, which means they are allocated as an Elixir binary and direct operations like `Nx.sum(tensor)` use an Elixir implementation.

Using EXLA for acceleration has two levels:

  1. `EXLA.Backend` - when set as the default backend, tensor allocation and individual operations are delegated to XLA, you basically always want to do that.

  2. `EXLA` compiler - you can use EXLA to compile whole `defn` functions/computations (such as model inference in the servings) into a platform-specific, optimised executable.

You already enable 2. for the serving with `defn_options: [compiler: EXLA]`. However, I noticed you don't do 1., which means `Bumblebee.load_model` loads parameters into `Nx.BinaryBackend`, so on every serving computation they need to be copied into `EXLA.Backend`. More importantly, `Bumblebee.load_model` does some processing on the parameters (mostly transpositions), and currently it happens using the Elixir implementation.

tl;dr this should make `Bumblebee.load_model` (and hence the app startup) much faster.